### PR TITLE
Add GLONASS L2 tracking to VEML block

### DIFF
--- a/src/algorithms/tracking/adapters/glonass_l2_ca_dll_pll_tracking.cc
+++ b/src/algorithms/tracking/adapters/glonass_l2_ca_dll_pll_tracking.cc
@@ -23,6 +23,7 @@
 #include "glonass_l2_ca_dll_pll_tracking.h"
 #include "GLONASS_L1_L2_CA.h"
 #include "configuration_interface.h"
+#include "gnss_sdr_flags.h"
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -48,6 +49,31 @@ void GlonassL2CaDllPllTracking::configure_tracking_parameters(const Configuratio
         {
             config_params().extend_correlation_symbols = 1;
         }
+    config_params().early_late_space_chips = configuration->property(role() + ".early_late_space_chips", static_cast<float>(0.5F));
+    config_params().pll_bw_hz = configuration->property(role() + ".pll_bw_hz", static_cast<float>(50.0));
+#if USE_GLOG_AND_GFLAGS
+    if (FLAGS_pll_bw_hz != 0.0)
+        {
+            config_params().pll_bw_hz = static_cast<float>(FLAGS_pll_bw_hz);
+        }
+#else
+    if (absl::GetFlag(FLAGS_pll_bw_hz) != 0.0)
+        {
+            config_params().pll_bw_hz = static_cast<float>(absl::GetFlag(FLAGS_pll_bw_hz));
+        }
+#endif
+    config_params().dll_bw_hz = configuration->property(role() + ".dll_bw_hz", static_cast<float>(2.0));
+#if USE_GLOG_AND_GFLAGS
+    if (FLAGS_dll_bw_hz != 0.0)
+        {
+            config_params().dll_bw_hz = static_cast<float>(FLAGS_dll_bw_hz);
+        }
+#else
+    if (absl::GetFlag(FLAGS_dll_bw_hz) != 0.0)
+        {
+            config_params().dll_bw_hz = static_cast<float>(absl::GetFlag(FLAGS_dll_bw_hz));
+        }
+#endif
     config_params().track_pilot = false;
     config_params().system = 'R';
     const std::array<char, 3> sig{'2', 'G', '\0'};

--- a/src/algorithms/tracking/adapters/glonass_l2_ca_dll_pll_tracking.cc
+++ b/src/algorithms/tracking/adapters/glonass_l2_ca_dll_pll_tracking.cc
@@ -23,146 +23,48 @@
 #include "glonass_l2_ca_dll_pll_tracking.h"
 #include "GLONASS_L1_L2_CA.h"
 #include "configuration_interface.h"
-#include "gnss_sdr_flags.h"
-#include <utility>
-
-#if USE_GLOG_AND_GFLAGS
-#include <glog/logging.h>
-#else
-#include <absl/log/log.h>
-#endif
-
+#include <algorithm>
+#include <array>
+#include <cmath>
 
 GlonassL2CaDllPllTracking::GlonassL2CaDllPllTracking(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
-    : role_(role),
-      item_size_(sizeof(gr_complex)),
-      channel_(0),
-      in_streams_(in_streams),
-      out_streams_(out_streams)
+    : BaseDllPllTracking(configuration, role, in_streams, out_streams)
 {
-    // ################# CONFIGURATION PARAMETERS ########################
-    const std::string default_item_type("gr_complex");
-    std::string item_type = configuration->property(role_ + ".item_type", default_item_type);
-    int fs_in_deprecated = configuration->property("GNSS-SDR.internal_fs_hz", 2048000);
-    int fs_in = configuration->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
-    bool dump = configuration->property(role_ + ".dump", false);
-    float pll_bw_hz = configuration->property(role_ + ".pll_bw_hz", static_cast<float>(50.0));
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_pll_bw_hz != 0.0)
-        {
-            pll_bw_hz = static_cast<float>(FLAGS_pll_bw_hz);
-        }
-#else
-    if (absl::GetFlag(FLAGS_pll_bw_hz) != 0.0)
-        {
-            pll_bw_hz = static_cast<float>(absl::GetFlag(FLAGS_pll_bw_hz));
-        }
-#endif
-    float dll_bw_hz = configuration->property(role_ + ".dll_bw_hz", static_cast<float>(2.0));
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_dll_bw_hz != 0.0)
-        {
-            dll_bw_hz = static_cast<float>(FLAGS_dll_bw_hz);
-        }
-#else
-    if (absl::GetFlag(FLAGS_dll_bw_hz) != 0.0)
-        {
-            dll_bw_hz = static_cast<float>(absl::GetFlag(FLAGS_dll_bw_hz));
-        }
-#endif
-    float early_late_space_chips = configuration->property(role_ + ".early_late_space_chips", static_cast<float>(0.5));
-    const std::string default_dump_filename("./track_ch");
-    std::string dump_filename = configuration->property(role_ + ".dump_filename", default_dump_filename);
-    const auto vector_length = static_cast<int>(std::round(fs_in / (GLONASS_L2_CA_CODE_RATE_CPS / GLONASS_L2_CA_CODE_LENGTH_CHIPS)));
+    configure_tracking_parameters(configuration);
+    create_tracking_block();
+}
 
-    // ################# MAKE TRACKING GNURadio object ###################
-    DLOG(INFO) << "role " << role_;
-    if (item_type == "gr_complex")
+
+void GlonassL2CaDllPllTracking::configure_tracking_parameters(const ConfigurationInterface* configuration)
+{
+    const auto vector_length = static_cast<int>(std::round(static_cast<double>(config_params().fs_in) /
+        (static_cast<double>(GLONASS_L2_CA_CODE_RATE_CPS) / static_cast<double>(GLONASS_L2_CA_CODE_LENGTH_CHIPS))));
+    config_params().vector_length = vector_length;
+    if (config_params().extend_correlation_symbols != 1)
         {
-            tracking_sptr_ = glonass_l2_ca_dll_pll_make_tracking_cc(
-                fs_in,
-                vector_length,
-                dump,
-                dump_filename,
-                pll_bw_hz,
-                dll_bw_hz,
-                early_late_space_chips);
-            DLOG(INFO) << "tracking(" << tracking_sptr_->unique_id() << ")";
+            config_params().extend_correlation_symbols = 1;
+        }
+    config_params().track_pilot = false;
+    config_params().system = 'R';
+    const std::array<char, 3> sig{'2', 'G', '\0'};
+    std::copy_n(sig.data(), 3, config_params().signal);
+    config_params().enable_fll_steady_state = configuration->property(role() + ".enable_fll_steady_state", false);
+}
+
+
+void GlonassL2CaDllPllTracking::create_tracking_block()
+{
+    if (config_params().item_type == "gr_complex")
+        {
+            tracking_sptr_ = dll_pll_veml_make_tracking(config_params());
         }
     else
         {
-            item_size_ = 0;
+            set_item_size(0);
             tracking_sptr_ = nullptr;
-            LOG(WARNING) << item_type << " unknown tracking item type.";
         }
-
-    if (in_streams_ > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one input stream";
-        }
-    if (out_streams_ > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one output stream";
-        }
-}
-
-
-void GlonassL2CaDllPllTracking::stop_tracking()
-{
-}
-
-
-void GlonassL2CaDllPllTracking::start_tracking()
-{
-    tracking_sptr_->start_tracking();
-}
-
-
-/*
- * Set tracking channel unique ID
- */
-void GlonassL2CaDllPllTracking::set_channel(unsigned int channel)
-{
-    channel_ = channel;
-    tracking_sptr_->set_channel(channel);
-}
-
-
-void GlonassL2CaDllPllTracking::set_gnss_synchro(Gnss_Synchro* p_gnss_synchro)
-{
-    tracking_sptr_->set_gnss_synchro(p_gnss_synchro);
-}
-
-
-void GlonassL2CaDllPllTracking::connect(gr::top_block_sptr top_block)
-{
-    if (top_block)
-        { /* top_block is not null */
-        };
-    // nothing to connect, now the tracking uses gr_sync_decimator
-}
-
-
-void GlonassL2CaDllPllTracking::disconnect(gr::top_block_sptr top_block)
-{
-    if (top_block)
-        { /* top_block is not null */
-        };
-    // nothing to disconnect, now the tracking uses gr_sync_decimator
-}
-
-
-gr::basic_block_sptr GlonassL2CaDllPllTracking::get_left_block()
-{
-    return tracking_sptr_;
-}
-
-
-gr::basic_block_sptr GlonassL2CaDllPllTracking::get_right_block()
-{
-    return tracking_sptr_;
 }

--- a/src/algorithms/tracking/adapters/glonass_l2_ca_dll_pll_tracking.h
+++ b/src/algorithms/tracking/adapters/glonass_l2_ca_dll_pll_tracking.h
@@ -24,9 +24,7 @@
 #ifndef GNSS_SDR_GLONASS_L2_CA_DLL_PLL_TRACKING_H
 #define GNSS_SDR_GLONASS_L2_CA_DLL_PLL_TRACKING_H
 
-#include "glonass_l2_ca_dll_pll_tracking_cc.h"
-#include "tracking_interface.h"
-#include <string>
+#include "base_dll_pll_tracking.h"
 
 /** \addtogroup Tracking
  * \{ */
@@ -39,7 +37,7 @@ class ConfigurationInterface;
 /*!
  * \brief This class implements a code DLL + carrier PLL tracking loop
  */
-class GlonassL2CaDllPllTracking : public TrackingInterface
+class GlonassL2CaDllPllTracking : public BaseDllPllTracking
 {
 public:
     GlonassL2CaDllPllTracking(
@@ -48,12 +46,7 @@ public:
         unsigned int in_streams,
         unsigned int out_streams);
 
-    ~GlonassL2CaDllPllTracking() = default;
-
-    inline std::string role() override
-    {
-        return role_;
-    }
+    ~GlonassL2CaDllPllTracking() override = default;
 
     //! Returns "GLONASS_L1_CA_DLL_PLL_Tracking"
     inline std::string implementation() override
@@ -61,41 +54,9 @@ public:
         return "GLONASS_L2_CA_DLL_PLL_Tracking";
     }
 
-    inline size_t item_size() override
-    {
-        return item_size_;
-    }
-
-    void connect(gr::top_block_sptr top_block) override;
-    void disconnect(gr::top_block_sptr top_block) override;
-    gr::basic_block_sptr get_left_block() override;
-    gr::basic_block_sptr get_right_block() override;
-
-    /*!
-     * \brief Set tracking channel unique ID
-     */
-    void set_channel(unsigned int channel) override;
-
-    /*!
-     * \brief Set acquisition/tracking common Gnss_Synchro object pointer
-     * to efficiently exchange synchronization data between acquisition and tracking blocks
-     */
-    void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
-
-    void start_tracking() override;
-
-    /*!
-     * \brief Stop running tracking
-     */
-    void stop_tracking() override;
-
 private:
-    glonass_l2_ca_dll_pll_tracking_cc_sptr tracking_sptr_;
-    std::string role_;
-    size_t item_size_;
-    unsigned int channel_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
+    void configure_tracking_parameters(const ConfigurationInterface* configuration) override;
+    void create_tracking_block() override;
 };
 
 

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
@@ -30,6 +30,7 @@
 #include "Galileo_E5a.h"
 #include "Galileo_E5b.h"
 #include "Galileo_E6.h"
+#include "GLONASS_L1_L2_CA.h"
 #include "MATH_CONSTANTS.h"
 #include "beidou_b1i_signal_replica.h"
 #include "beidou_b3i_signal_replica.h"
@@ -43,6 +44,7 @@
 #include "gps_l2c_signal_replica.h"
 #include "gps_l5_signal_replica.h"
 #include "gps_sdr_signal_replica.h"
+#include "glonass_l2_signal_replica.h"
 #include "lock_detectors.h"
 #include "matlab_writter_helper.h"
 #include "tracking_discriminators.h"
@@ -436,6 +438,37 @@ dll_pll_veml_tracking::dll_pll_veml_tracking(const Dll_Pll_Conf &conf_)
                     d_secondary_code_string = BEIDOU_B3I_SECONDARY_CODE_STR;
                     d_data_secondary_code_length = static_cast<uint32_t>(BEIDOU_B3I_SECONDARY_CODE_LENGTH);
                     d_data_secondary_code_string = BEIDOU_B3I_SECONDARY_CODE_STR;
+                }
+            else
+                {
+                    LOG(WARNING) << "Invalid Signal argument when instantiating tracking blocks";
+                    std::cout << "Invalid Signal argument when instantiating tracking blocks\n";
+                    d_correlation_length_ms = 1;
+                    d_secondary = false;
+                    d_signal_carrier_freq = 0.0;
+                    d_code_period = 0.0;
+                    d_code_length_chips = 0;
+                    d_code_samples_per_chip = 0;
+                    d_symbols_per_bit = 0;
+                }
+        }
+    else if (d_trk_parameters.system == 'R')
+        {
+            d_systemName = "Glonass";
+            if (d_signal_type == "2G")
+                {
+                    d_signal_carrier_freq = GLONASS_L2_CA_FREQ_HZ;
+                    d_code_period = GLONASS_L2_CA_CODE_PERIOD_S;
+                    d_code_chip_rate = GLONASS_L2_CA_CODE_RATE_CPS;
+                    d_correlation_length_ms = 1;
+                    d_code_samples_per_chip = 1;
+                    d_code_length_chips = static_cast<int32_t>(GLONASS_L2_CA_CODE_LENGTH_CHIPS);
+                    d_secondary = false;
+                    d_trk_parameters.track_pilot = false;
+                    d_trk_parameters.slope = 1.0F;
+                    d_trk_parameters.spc = d_trk_parameters.early_late_space_chips;
+                    d_trk_parameters.y_intercept = 1.0F;
+                    d_symbols_per_bit = GLONASS_GNAV_TELEMETRY_SYMBOLS_PER_BIT;
                 }
             else
                 {
@@ -844,6 +877,20 @@ void dll_pll_veml_tracking::start_tracking()
                     d_data_secondary_code_length = static_cast<uint32_t>(BEIDOU_B3I_SECONDARY_CODE_LENGTH);
                     d_data_secondary_code_string = BEIDOU_B3I_SECONDARY_CODE_STR;
                     d_Prompt_circular_buffer.set_capacity(d_secondary_code_length);
+                }
+        }
+    else if (d_systemName == "Glonass" and d_signal_type == "2G")
+        {
+            const double glonass_channel_frequency = GLONASS_L2_CA_FREQ_HZ + (DFRQ2_GLO * GLONASS_PRN.at(d_acquisition_gnss_synchro->PRN));
+            d_signal_carrier_freq = glonass_channel_frequency;
+            // initial code frequency including Doppler effect on chip rate
+            d_code_freq_chips = d_code_chip_rate + ((d_carrier_doppler_hz * d_code_chip_rate) / d_signal_carrier_freq);
+
+            volk_gnsssdr::vector<gr_complex> aux_code(static_cast<size_t>(d_code_length_chips));
+            glonass_l2_ca_code_gen_complex(own::span<gr_complex>(aux_code.data(), static_cast<size_t>(d_code_length_chips)), 0);
+            for (int32_t i = 0; i < d_code_length_chips; i++)
+                {
+                    d_tracking_code[i] = aux_code[static_cast<size_t>(i)].real();
                 }
         }
 

--- a/src/algorithms/tracking/gnuradio_blocks/glonass_l2_ca_dll_pll_tracking_cc.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/glonass_l2_ca_dll_pll_tracking_cc.cc
@@ -84,7 +84,7 @@ Glonass_L2_Ca_Dll_Pll_Tracking_cc::Glonass_L2_Ca_Dll_Pll_Tracking_cc(
     float pll_bw_hz,
     float dll_bw_hz,
     float early_late_space_chips)
-    : gr::block("Glonass_L1_Ca_Dll_Pll_Tracking_cc", gr::io_signature::make(1, 1, sizeof(gr_complex)),
+    : gr::block("Glonass_L2_Ca_Dll_Pll_Tracking_cc", gr::io_signature::make(1, 1, sizeof(gr_complex)),
           gr::io_signature::make(1, 1, sizeof(Gnss_Synchro))),
       d_dump_filename(dump_filename),
       d_acquisition_gnss_synchro(nullptr),


### PR DESCRIPTION
## Summary
- extend the generic DLL/PLL VEML tracking block to generate GLONASS L2 C/A replicas and use channel-specific carrier frequencies
- move the GLONASS L2 tracking adapter onto the shared BaseDllPllTracking path so it instantiates the VEML block

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932af84e584832c82b7295adc1ab6c5)