### PR TITLE
Detect carrier cycle slips in observables and add `flag_cycle_slip` to GnssSynchro proto

### DIFF
--- a/docs/protobuf/gnss_synchro.proto
+++ b/docs/protobuf/gnss_synchro.proto
@@ -37,6 +37,7 @@ message GnssSynchro {
   bool flag_valid_pseudorange = 24;         // Pseudorange computation status
   double interp_tow_ms = 25;                // Interpolated time of week, in ms
   bool flag_PLL_180_deg_phase_locked = 26;  // PLL lock at 180º
+  bool flag_cycle_slip = 27;                // Carrier cycle slip detection flag
 }
 
 /* Observables represents a collection of GnssSynchro annotations */

--- a/src/algorithms/PVT/libs/rinex_printer.cc
+++ b/src/algorithms/PVT/libs/rinex_printer.cc
@@ -1277,20 +1277,21 @@ std::string get_obs_epoch_record_lines(const boost::posix_time::ptime& utc_time,
 void add_obs_sat_record_line(const Gnss_Synchro& synchro, std::string& line, bool padding = true)
 {
     const int32_t ssi = signal_strength(synchro.CN0_dB_hz);
+    const char lli = synchro.Flag_cycle_slip ? '1' : ' ';
 
     // PSEUDORANGE
     line += rightJustify(asString(synchro.Pseudorange_m, 3), 14);
-    line += std::string(1, ' ');                      // Loss of lock indicator (LLI)
+    line += std::string(1, lli);                      // Loss of lock indicator (LLI)
     line += rightJustify(asString<int32_t>(ssi), 1);  // Signal Strength Indicator (SSI)
 
     // PHASE
     line += rightJustify(asString(synchro.Carrier_phase_rads / TWO_PI, 3), 14);
-    line += std::string(1, ' ');                      // Loss of lock indicator (LLI)
+    line += std::string(1, lli);                      // Loss of lock indicator (LLI)
     line += rightJustify(asString<int32_t>(ssi), 1);  // Signal Strength Indicator (SSI)
 
     // DOPPLER
     line += rightJustify(asString(synchro.Carrier_Doppler_hz, 3), 14);
-    line += std::string(1, ' ');                      // Loss of lock indicator (LLI)
+    line += std::string(1, lli);                      // Loss of lock indicator (LLI)
     line += rightJustify(asString<int32_t>(ssi), 1);  // Signal Strength Indicator (SSI)
 
     // SIGNAL STRENGTH

--- a/src/algorithms/libs/rtklib/rtklib_conversions.cc
+++ b/src/algorithms/libs/rtklib/rtklib_conversions.cc
@@ -43,6 +43,7 @@ obsd_t insert_obs_to_rtklib(obsd_t& rtklib_obs,
     rtklib_obs.D[band] = gnss_synchro.Carrier_Doppler_hz;
     rtklib_obs.P[band] = gnss_synchro.Pseudorange_m;
     rtklib_obs.L[band] = gnss_synchro.Carrier_phase_rads / TWO_PI;
+    rtklib_obs.LLI[band] = gnss_synchro.Flag_cycle_slip ? 1U : 0U;
 
     switch (band)
         {

--- a/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.cc
+++ b/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.cc
@@ -105,6 +105,8 @@ hybrid_observables_gs::hybrid_observables_gs(const Obs_Conf &conf_)
     d_channel_last_pll_lock = std::vector<bool>(d_nchannels_out, false);
     d_channel_last_pseudorange_smooth = std::vector<double>(d_nchannels_out, 0.0);
     d_channel_last_carrier_phase_rads = std::vector<double>(d_nchannels_out, 0.0);
+    d_channel_last_rx_time_s = std::vector<double>(d_nchannels_out, 0.0);
+    d_channel_last_rx_time_valid = std::vector<bool>(d_nchannels_out, false);
 
     d_SourceTagTimestamps = std::vector<std::queue<GnssTime>>(d_nchannels_out);
 
@@ -216,6 +218,7 @@ void hybrid_observables_gs::msg_handler_pvt_to_observables(const pmt::pmt_t &msg
                         {
                             d_gnss_synchro_history->clear(n);
                         }
+                    std::fill(d_channel_last_rx_time_valid.begin(), d_channel_last_rx_time_valid.end(), false);
 
                     LOG(INFO) << "Corrected new RX Time offset: " << static_cast<int>(round(new_rx_clock_offset_s * 1000.0)) << "[ms]";
                 }
@@ -232,6 +235,7 @@ void hybrid_observables_gs::msg_handler_pvt_to_observables(const pmt::pmt_t &msg
                                 {
                                     d_gnss_synchro_history->clear(n);
                                 }
+                            std::fill(d_channel_last_rx_time_valid.begin(), d_channel_last_rx_time_valid.end(), false);
                             LOG(INFO) << "Received reset observables TOW command from PVT";
                             break;
                         default:
@@ -586,6 +590,88 @@ void hybrid_observables_gs::smooth_pseudoranges(std::vector<Gnss_Synchro> &data)
         }
 }
 
+void hybrid_observables_gs::detect_cycle_slips(std::vector<Gnss_Synchro> &data, uint64_t rx_clock)
+{
+    constexpr double kCycleSlipThresholdCycles = 0.5;
+
+    std::vector<double> residuals;
+    std::vector<uint32_t> channels;
+    residuals.reserve(data.size());
+    channels.reserve(data.size());
+
+    for (auto &obs : data)
+        {
+            obs.Flag_cycle_slip = false;
+        }
+
+    for (uint32_t n = 0; n < d_nchannels_out; n++)
+        {
+            auto &obs = data[n];
+            if (!obs.Flag_valid_pseudorange || obs.fs == 0LL)
+                {
+                    d_channel_last_rx_time_valid[n] = false;
+                    continue;
+                }
+
+            const auto step_samples = static_cast<uint64_t>(llround(d_T_rx_step_s * static_cast<double>(obs.fs)));
+            if (step_samples == 0 || rx_clock <= step_samples)
+                {
+                    d_channel_last_rx_time_s[n] = obs.RX_time;
+                    d_channel_last_rx_time_valid[n] = true;
+                    continue;
+                }
+
+            Gnss_Synchro prev_obs{};
+            if (!interp_trk_obs(prev_obs, n, rx_clock - step_samples))
+                {
+                    d_channel_last_rx_time_s[n] = obs.RX_time;
+                    d_channel_last_rx_time_valid[n] = true;
+                    continue;
+                }
+
+            const double current_phase_cycles = obs.Carrier_phase_rads / TWO_PI;
+            const double previous_phase_cycles = prev_obs.Carrier_phase_rads / TWO_PI;
+            const double delta_phase_cycles = current_phase_cycles - previous_phase_cycles;
+
+            double dt = d_T_rx_step_s;
+            if (d_channel_last_rx_time_valid[n])
+                {
+                    const double dt_candidate = obs.RX_time - d_channel_last_rx_time_s[n];
+                    if (dt_candidate > 0.0)
+                        {
+                            dt = dt_candidate;
+                        }
+                }
+
+            const double residual = delta_phase_cycles + obs.Carrier_Doppler_hz * dt;
+            residuals.push_back(residual);
+            channels.push_back(n);
+
+            d_channel_last_rx_time_s[n] = obs.RX_time;
+            d_channel_last_rx_time_valid[n] = true;
+        }
+
+    if (residuals.empty())
+        {
+            return;
+        }
+
+    std::vector<double> sorted_residuals = residuals;
+    std::sort(sorted_residuals.begin(), sorted_residuals.end());
+    const size_t mid = sorted_residuals.size() / 2;
+    const double offset = (sorted_residuals.size() % 2 == 0)
+                              ? 0.5 * (sorted_residuals[mid - 1] + sorted_residuals[mid])
+                              : sorted_residuals[mid];
+
+    for (size_t i = 0; i < residuals.size(); i++)
+        {
+            if (std::abs(residuals[i] - offset) > kCycleSlipThresholdCycles)
+                {
+                    data[channels[i]].Flag_cycle_slip = true;
+                }
+        }
+}
+
 
 void hybrid_observables_gs::set_tag_timestamp_in_sdr_timeframe(const std::vector<Gnss_Synchro> &data, uint64_t rx_clock)
 {
@@ -773,6 +859,7 @@ int hybrid_observables_gs::general_work(int noutput_items __attribute__((unused)
                                     if (d_gnss_synchro_history->front(n).PRN != in[n][m].PRN)
                                         {
                                             d_gnss_synchro_history->clear(n);
+                                            d_channel_last_rx_time_valid[n] = false;
                                             // LOG(INFO) << "Channel " << d_gnss_synchro_history->front(n).Channel_ID << " changed satellite to PRN " << in[n][m].PRN;
                                         }
                                 }
@@ -829,6 +916,11 @@ int hybrid_observables_gs::general_work(int noutput_items __attribute__((unused)
             if (d_conf.enable_carrier_smoothing == true)
                 {
                     smooth_pseudoranges(epoch_data);
+                }
+
+            if (n_valid > 0)
+                {
+                    detect_cycle_slips(epoch_data, d_Rx_clock_buffer.front());
                 }
 
             // output the observables set to the PVT block

--- a/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.h
+++ b/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.h
@@ -77,6 +77,7 @@ private:
     void update_TOW(const std::vector<Gnss_Synchro>& data);
     void compute_pranges(std::vector<Gnss_Synchro>& data) const;
     void smooth_pseudoranges(std::vector<Gnss_Synchro>& data);
+    void detect_cycle_slips(std::vector<Gnss_Synchro>& data, uint64_t rx_clock);
 
     void set_tag_timestamp_in_sdr_timeframe(const std::vector<Gnss_Synchro>& data, uint64_t rx_clock);
 
@@ -99,6 +100,8 @@ private:
     std::vector<bool> d_channel_last_pll_lock;
     std::vector<double> d_channel_last_pseudorange_smooth;
     std::vector<double> d_channel_last_carrier_phase_rads;
+    std::vector<double> d_channel_last_rx_time_s;
+    std::vector<bool> d_channel_last_rx_time_valid;
 
     std::string d_dump_filename;
 

--- a/src/core/monitor/serdes_gnss_synchro.h
+++ b/src/core/monitor/serdes_gnss_synchro.h
@@ -113,6 +113,7 @@ public:
                 obs->set_rx_time(gs.RX_time);
                 obs->set_flag_valid_pseudorange(gs.Flag_valid_pseudorange);
                 obs->set_flag_pll_180_deg_phase_locked(gs.Flag_PLL_180_deg_phase_locked);
+                obs->set_flag_cycle_slip(gs.Flag_cycle_slip);
                 obs->set_interp_tow_ms(gs.interp_TOW_ms);
             }
         observables.SerializeToString(&data);
@@ -158,6 +159,7 @@ public:
                 gs.RX_time = gs_read.rx_time();
                 gs.Flag_valid_pseudorange = gs_read.flag_valid_pseudorange();
                 gs.Flag_PLL_180_deg_phase_locked = gs_read.flag_pll_180_deg_phase_locked();
+                gs.Flag_cycle_slip = gs_read.flag_cycle_slip();
                 gs.interp_TOW_ms = gs_read.interp_tow_ms();
 
                 vgs.push_back(gs);

--- a/src/core/system_parameters/gnss_synchro.h
+++ b/src/core/system_parameters/gnss_synchro.h
@@ -79,6 +79,7 @@ public:
     bool Flag_valid_word{};                //!< Set by Telemetry Decoder processing block
     bool Flag_valid_pseudorange{};         //!< Set by Observables processing block
     bool Flag_PLL_180_deg_phase_locked{};  //!< Set by Telemetry Decoder processing block
+    bool Flag_cycle_slip{};                //!< Set by Observables processing block
 
     /// Copy constructor
     Gnss_Synchro(const Gnss_Synchro& other) noexcept = default;
@@ -117,6 +118,7 @@ public:
                 this->Flag_valid_word = rhs.Flag_valid_word;
                 this->Flag_valid_pseudorange = rhs.Flag_valid_pseudorange;
                 this->Flag_PLL_180_deg_phase_locked = rhs.Flag_PLL_180_deg_phase_locked;
+                this->Flag_cycle_slip = rhs.Flag_cycle_slip;
             }
         return *this;
     };
@@ -187,6 +189,7 @@ public:
                 other.Flag_valid_word = false;
                 other.Flag_valid_pseudorange = false;
                 other.Flag_PLL_180_deg_phase_locked = false;
+                other.Flag_cycle_slip = false;
             }
         return *this;
     };
@@ -234,6 +237,7 @@ public:
         ar& BOOST_SERIALIZATION_NVP(Flag_valid_word);
         ar& BOOST_SERIALIZATION_NVP(Flag_valid_pseudorange);
         ar& BOOST_SERIALIZATION_NVP(Flag_PLL_180_deg_phase_locked);
+        ar& BOOST_SERIALIZATION_NVP(Flag_cycle_slip);
     }
 };
 


### PR DESCRIPTION
### Motivation
- Detect carrier cycle slips at the observables stage to improve downstream PVT/PPP robustness when receiver clock steps or per-satellite slips occur.
- Remove per-epoch common-mode before flagging to avoid spurious flags caused by receiver-wide clock steps.
- Maintain per-channel detector state so clock corrections or channel-to-satellite switches do not produce false detections.
- Expose the detection result in the protobuf schema so downstream components can consume the flag.

### Description
- Added `bool Flag_cycle_slip` to the `Gnss_Synchro` structure and included it in the copy/move operators and `serialize` implementation in `src/core/system_parameters/gnss_synchro.h`.
- Implemented `detect_cycle_slips` in `src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.cc` and declared it in the header, which computes residuals `r = Δphase_cycles + Doppler * dt`, estimates a median common-mode offset, and flags outliers beyond a threshold by setting `Flag_cycle_slip`.
- Added per-channel state members `d_channel_last_rx_time_s` and `d_channel_last_rx_time_valid`, cleared on RX clock corrections and channel satellite changes, and invoked `detect_cycle_slips` after `compute_pranges` (and after smoothing when enabled).
- Updated the protobuf definition in `docs/protobuf/gnss_synchro.proto` to add `flag_cycle_slip = 27;` so the flag is available to consumers.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695261190088832c849f294db9256284)