### PR TITLE
Add histogram-based bit synchronization to DLL/PLL tracking

### DIFF
--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
@@ -134,7 +134,9 @@ dll_pll_veml_tracking::dll_pll_veml_tracking(const Dll_Pll_Conf &conf_)
       d_dump(d_trk_parameters.dump),
       d_dump_mat(d_trk_parameters.dump_mat && d_dump),
       d_acc_carrier_phase_initialized(false),
-      d_Flag_PLL_180_deg_phase_locked(false)
+      d_Flag_PLL_180_deg_phase_locked(false),
+      d_use_histogram_bit_sync(false),
+      d_bit_sync(HistogramBitSynchronizer::Config())
 {
 #if GNURADIO_GREATER_THAN_38
     this->set_relative_rate(1, static_cast<uint64_t>(d_trk_parameters.vector_length));
@@ -978,6 +980,7 @@ void dll_pll_veml_tracking::start_tracking()
     d_Prompt_circular_buffer.clear();
     d_corrected_doppler = false;
     d_acc_carrier_phase_initialized = false;
+    configure_bit_synchronizer();
 }
 
 
@@ -1283,6 +1286,23 @@ void dll_pll_veml_tracking::clear_tracking_vars()
     d_wn_from_telemetry = 0;
     d_carr_ph_history.clear();
     d_code_ph_history.clear();
+    d_bit_sync.reset();
+}
+
+
+void dll_pll_veml_tracking::configure_bit_synchronizer()
+{
+    d_use_histogram_bit_sync = (!d_secondary && d_symbols_per_bit > 1);
+    if (!d_use_histogram_bit_sync)
+        {
+            d_bit_sync.reset();
+            return;
+        }
+
+    HistogramBitSynchronizer::Config cfg;
+    cfg.bit_period_ms = d_symbols_per_bit * d_correlation_length_ms;
+    cfg.epoch_ms = d_correlation_length_ms;
+    d_bit_sync = HistogramBitSynchronizer(cfg);
 }
 
 
@@ -1923,17 +1943,32 @@ int dll_pll_veml_tracking::general_work(int noutput_items __attribute__((unused)
                                     }
                                 else if (d_symbols_per_bit > 1)  // Signal does not have secondary code. Search a bit transition by sign change
                                     {
-                                        // ******* preamble correlation ********
-                                        d_Prompt_circular_buffer.push_back(*d_Prompt);
-                                        if (d_Prompt_circular_buffer.size() == d_secondary_code_length)
+                                        if (d_use_histogram_bit_sync)
                                             {
-                                                next_state = acquire_secondary();
+                                                next_state = d_bit_sync.update(d_P_accu, true);
                                                 if (next_state)
                                                     {
-                                                        LOG(INFO) << d_systemName << " " << d_signal_pretty_name << " tracking bit synchronization locked in channel " << d_channel
+                                                        LOG(INFO) << d_systemName << " " << d_signal_pretty_name << " histogram bit synchronization locked in channel " << d_channel
                                                                   << " for satellite " << Gnss_Satellite(d_systemName, d_acquisition_gnss_synchro->PRN);
-                                                        std::cout << d_systemName << " " << d_signal_pretty_name << " tracking bit synchronization locked in channel " << d_channel
+                                                        std::cout << d_systemName << " " << d_signal_pretty_name << " histogram bit synchronization locked in channel " << d_channel
                                                                   << " for satellite " << Gnss_Satellite(d_systemName, d_acquisition_gnss_synchro->PRN) << '\n';
+                                                    }
+                                            }
+
+                                        if (!next_state)
+                                            {
+                                                // ******* preamble correlation ********
+                                                d_Prompt_circular_buffer.push_back(*d_Prompt);
+                                                if (d_Prompt_circular_buffer.size() == d_secondary_code_length)
+                                                    {
+                                                        next_state = acquire_secondary();
+                                                        if (next_state)
+                                                            {
+                                                                LOG(INFO) << d_systemName << " " << d_signal_pretty_name << " tracking bit synchronization locked in channel " << d_channel
+                                                                          << " for satellite " << Gnss_Satellite(d_systemName, d_acquisition_gnss_synchro->PRN);
+                                                                std::cout << d_systemName << " " << d_signal_pretty_name << " tracking bit synchronization locked in channel " << d_channel
+                                                                          << " for satellite " << Gnss_Satellite(d_systemName, d_acquisition_gnss_synchro->PRN) << '\n';
+                                                            }
                                                     }
                                             }
                                     }

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
@@ -136,6 +136,8 @@ dll_pll_veml_tracking::dll_pll_veml_tracking(const Dll_Pll_Conf &conf_)
       d_acc_carrier_phase_initialized(false),
       d_Flag_PLL_180_deg_phase_locked(false),
       d_use_histogram_bit_sync(false),
+      d_wait_for_bit_edge(false),
+      d_bit_sync_lock_epoch(0),
       d_bit_sync(HistogramBitSynchronizer::Config())
 {
 #if GNURADIO_GREATER_THAN_38
@@ -1287,6 +1289,8 @@ void dll_pll_veml_tracking::clear_tracking_vars()
     d_carr_ph_history.clear();
     d_code_ph_history.clear();
     d_bit_sync.reset();
+    d_wait_for_bit_edge = false;
+    d_bit_sync_lock_epoch = 0;
 }
 
 
@@ -1296,6 +1300,8 @@ void dll_pll_veml_tracking::configure_bit_synchronizer()
     if (!d_use_histogram_bit_sync)
         {
             d_bit_sync.reset();
+            d_wait_for_bit_edge = false;
+            d_bit_sync_lock_epoch = 0;
             return;
         }
 
@@ -1303,6 +1309,8 @@ void dll_pll_veml_tracking::configure_bit_synchronizer()
     cfg.bit_period_ms = d_symbols_per_bit * d_correlation_length_ms;
     cfg.epoch_ms = d_correlation_length_ms;
     d_bit_sync = HistogramBitSynchronizer(cfg);
+    d_wait_for_bit_edge = false;
+    d_bit_sync_lock_epoch = 0;
 }
 
 
@@ -1945,13 +1953,23 @@ int dll_pll_veml_tracking::general_work(int noutput_items __attribute__((unused)
                                     {
                                         if (d_use_histogram_bit_sync)
                                             {
-                                                next_state = d_bit_sync.update(d_P_accu, true);
-                                                if (next_state)
+                                                if (d_bit_sync.update(d_P_accu, true))
                                                     {
+                                                        if (!d_wait_for_bit_edge)
+                                                            {
+                                                                d_wait_for_bit_edge = true;
+                                                                d_bit_sync_lock_epoch = d_bit_sync.epoch_count();
+                                                            }
                                                         LOG(INFO) << d_systemName << " " << d_signal_pretty_name << " histogram bit synchronization locked in channel " << d_channel
                                                                   << " for satellite " << Gnss_Satellite(d_systemName, d_acquisition_gnss_synchro->PRN);
                                                         std::cout << d_systemName << " " << d_signal_pretty_name << " histogram bit synchronization locked in channel " << d_channel
                                                                   << " for satellite " << Gnss_Satellite(d_systemName, d_acquisition_gnss_synchro->PRN) << '\n';
+                                                    }
+                                                if (d_wait_for_bit_edge &&
+                                                    d_bit_sync.is_edge_epoch(d_bit_sync.epoch_count()) &&
+                                                    d_bit_sync.epoch_count() > d_bit_sync_lock_epoch)
+                                                    {
+                                                        next_state = true;
                                                     }
                                             }
 
@@ -1983,6 +2001,7 @@ int dll_pll_veml_tracking::general_work(int noutput_items __attribute__((unused)
                             }
                         if (next_state)
                             {  // reset extended correlator
+                                d_wait_for_bit_edge = false;
                                 d_VE_accu = gr_complex(0.0, 0.0);
                                 d_E_accu = gr_complex(0.0, 0.0);
                                 d_P_accu = gr_complex(0.0, 0.0);

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.h
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.h
@@ -33,12 +33,16 @@
 #include <gnuradio/types.h>                   // for gr_vector_int, gr_vector...
 #include <pmt/pmt.h>                          // for pmt_t
 #include <volk_gnsssdr/volk_gnsssdr_alloc.h>  // for volk_gnsssdr::vector
+#include <algorithm>                          // for fill
+#include <cmath>                              // for abs
+#include <complex>                            // for complex
 #include <cstddef>                            // for size_t
 #include <cstdint>                            // for int32_t
 #include <fstream>                            // for ofstream
 #include <string>                             // for string
 #include <typeinfo>                           // for typeid
 #include <utility>                            // for pair
+#include <vector>                             // for vector
 
 /** \addtogroup Tracking
  * \{ */
@@ -53,6 +57,198 @@ class dll_pll_veml_tracking;
 using dll_pll_veml_tracking_sptr = gnss_shared_ptr<dll_pll_veml_tracking>;
 
 dll_pll_veml_tracking_sptr dll_pll_veml_make_tracking(const Dll_Pll_Conf &conf_);
+
+class HistogramBitSynchronizer
+{
+public:
+    struct Config
+    {
+        int bit_period_ms;
+        int epoch_ms;
+        int min_events_for_lock;
+        double dominance_ratio;
+        int stable_best_required;
+        float min_prompt_mag;
+        bool use_phase_dot_detector;
+
+        Config()
+            : bit_period_ms(20),
+              epoch_ms(1),
+              min_events_for_lock(30),
+              dominance_ratio(0.55),
+              stable_best_required(5),
+              min_prompt_mag(0.0f),
+              use_phase_dot_detector(true)
+        {
+        }
+    };
+
+    explicit HistogramBitSynchronizer(const Config &cfg)
+        : cfg_(cfg),
+          total_events_(0),
+          epoch_count_(0),
+          locked_(false),
+          edge_phase_(-1),
+          has_last_prompt_(false),
+          last_prompt_(0.0f, 0.0f),
+          has_last_sign_(false),
+          last_sign_(+1),
+          has_last_best_bin_(false),
+          last_best_bin_(0),
+          stable_best_count_(0)
+    {
+        hist_.assign(bins(), 0);
+    }
+
+    void reset()
+    {
+        std::fill(hist_.begin(), hist_.end(), 0);
+        total_events_ = 0;
+        epoch_count_ = 0;
+        locked_ = false;
+        edge_phase_ = -1;
+
+        has_last_prompt_ = false;
+        last_prompt_ = std::complex<float>(0.0f, 0.0f);
+
+        has_last_sign_ = false;
+        last_sign_ = +1;
+
+        has_last_best_bin_ = false;
+        last_best_bin_ = 0;
+        stable_best_count_ = 0;
+    }
+
+    bool update(const std::complex<float> &prompt, bool tracking_quality_ok)
+    {
+        const int N = bins();
+        const int phase = (N > 0) ? static_cast<int>(epoch_count_ % N) : 0;
+
+        ++epoch_count_;
+
+        if (!tracking_quality_ok || (std::abs(prompt) < cfg_.min_prompt_mag))
+            {
+                last_prompt_ = prompt;
+                has_last_prompt_ = true;
+                return false;
+            }
+
+        bool edge_event = false;
+
+        if (cfg_.use_phase_dot_detector)
+            {
+                if (has_last_prompt_)
+                    {
+                        const double dot = static_cast<double>(std::real(prompt * std::conj(last_prompt_)));
+                        edge_event = (dot < 0.0);
+                    }
+                last_prompt_ = prompt;
+                has_last_prompt_ = true;
+            }
+        else
+            {
+                const int s = (std::real(prompt) >= 0.0f) ? +1 : -1;
+                if (has_last_sign_)
+                    {
+                        edge_event = (s != last_sign_);
+                    }
+                last_sign_ = s;
+                has_last_sign_ = true;
+            }
+
+        if (edge_event && N > 0)
+            {
+                ++hist_[phase];
+                ++total_events_;
+            }
+
+        if (!locked_ && (total_events_ >= cfg_.min_events_for_lock))
+            {
+                int best_bin = 0;
+                int best_count = 0;
+                best_bin_and_count(best_bin, best_count);
+
+                const double ratio = (total_events_ > 0)
+                                         ? (static_cast<double>(best_count) / static_cast<double>(total_events_))
+                                         : 0.0;
+
+                if (!has_last_best_bin_ || (best_bin != last_best_bin_))
+                    {
+                        last_best_bin_ = best_bin;
+                        has_last_best_bin_ = true;
+                        stable_best_count_ = 1;
+                    }
+                else
+                    {
+                        ++stable_best_count_;
+                    }
+
+                if ((ratio >= cfg_.dominance_ratio) &&
+                    (stable_best_count_ >= cfg_.stable_best_required))
+                    {
+                        locked_ = true;
+                        edge_phase_ = best_bin;
+                        return true;
+                    }
+            }
+
+        return false;
+    }
+
+    bool locked() const { return locked_; }
+    int edge_phase() const { return edge_phase_; }
+
+    bool is_edge_epoch(std::int64_t k) const
+    {
+        if (!locked_ || edge_phase_ < 0) return false;
+        const int N = bins();
+        if (N <= 0) return false;
+        return (static_cast<int>(k % N) == edge_phase_);
+    }
+
+    int bins() const
+    {
+        const int N = (cfg_.epoch_ms > 0) ? (cfg_.bit_period_ms / cfg_.epoch_ms) : 0;
+        return (N > 0) ? N : 0;
+    }
+
+    const std::vector<int> &histogram() const { return hist_; }
+    std::int64_t total_events() const { return total_events_; }
+    std::int64_t epoch_count() const { return epoch_count_; }
+
+private:
+    void best_bin_and_count(int &best_bin, int &best_count) const
+    {
+        best_bin = 0;
+        best_count = (hist_.empty() ? 0 : hist_[0]);
+        for (int i = 1; i < static_cast<int>(hist_.size()); ++i)
+            {
+                if (hist_[i] > best_count)
+                    {
+                        best_count = hist_[i];
+                        best_bin = i;
+                    }
+            }
+    }
+
+    Config cfg_;
+    std::vector<int> hist_;
+    std::int64_t total_events_;
+    std::int64_t epoch_count_;
+
+    bool locked_;
+    int edge_phase_;
+
+    bool has_last_prompt_;
+    std::complex<float> last_prompt_;
+
+    bool has_last_sign_;
+    int last_sign_;
+
+    bool has_last_best_bin_;
+    int last_best_bin_;
+    int stable_best_count_;
+};
 
 /*!
  * \brief This class implements a code DLL + carrier PLL tracking block.
@@ -86,6 +282,7 @@ private:
     void log_data();
     bool cn0_and_tracking_lock_status(double coh_integration_time_s);
     bool acquire_secondary();
+    void configure_bit_synchronizer();
     int64_t uint64diff(uint64_t first, uint64_t second);
     int32_t save_matfile() const;
 
@@ -212,6 +409,8 @@ private:
     bool d_acc_carrier_phase_initialized;
     bool d_enable_extended_integration;
     bool d_Flag_PLL_180_deg_phase_locked;
+    bool d_use_histogram_bit_sync;
+    HistogramBitSynchronizer d_bit_sync;
 };
 
 

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.h
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.h
@@ -410,6 +410,8 @@ private:
     bool d_enable_extended_integration;
     bool d_Flag_PLL_180_deg_phase_locked;
     bool d_use_histogram_bit_sync;
+    bool d_wait_for_bit_edge;
+    std::int64_t d_bit_sync_lock_epoch;
     HistogramBitSynchronizer d_bit_sync;
 };
 


### PR DESCRIPTION
### Motivation
- Provide a histogram-driven bit synchronization method to detect telemetry bit edges for signals without a secondary code (e.g., multi-symbol-per-bit signals) and reduce reliance on preamble correlation alone.
- Allow a configurable detector (phase dot or sign-change) and a stable/robust lock decision based on dominance of a phase-bin in a histogram of edge events.

### Description
- Add a `HistogramBitSynchronizer` helper class to `dll_pll_veml_tracking.h` that implements a configurable histogram-based edge detector and lock logic with `update`, `reset`, `locked` and helper methods.
- Add members `d_use_histogram_bit_sync` and `d_bit_sync` to the `dll_pll_veml_tracking` class and include necessary headers (`<algorithm>`, `<cmath>`, `<complex>`, `<vector>`).
- Initialize the synchronizer in the tracker constructor (default config) and configure it via a new `configure_bit_synchronizer()` method which is called from `start_tracking()`; the synchronizer is reset from `clear_tracking_vars()`.
- Integrate the histogram method into the state-2 bit synchronization flow by calling `d_bit_sync.update(d_P_accu, true)` and logging when it declares lock, while retaining the existing preamble/preamble-correlation fallback via `acquire_secondary()` when histogram sync is not locked.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970a4348ae4832c8daf618910f2aafc)