### PR TITLE
Unify GLONASS bit synchronization selection

### DIFF
--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
@@ -136,7 +136,7 @@ dll_pll_veml_tracking::dll_pll_veml_tracking(const Dll_Pll_Conf &conf_)
       d_dump_mat(d_trk_parameters.dump_mat && d_dump),
       d_acc_carrier_phase_initialized(false),
       d_Flag_PLL_180_deg_phase_locked(false),
-      d_use_histogram_bit_sync(false)
+      d_use_bit_sync(false)
 {
 #if GNURADIO_GREATER_THAN_38
     this->set_relative_rate(1, static_cast<uint64_t>(d_trk_parameters.vector_length));
@@ -1292,14 +1292,17 @@ void dll_pll_veml_tracking::clear_tracking_vars()
 
 void dll_pll_veml_tracking::configure_bit_synchronizer()
 {
-    d_use_histogram_bit_sync = (!d_secondary && d_symbols_per_bit > 1) && (d_systemName != "Glonass");  // Glonass uses Manchester coding
-    if (!d_use_histogram_bit_sync)
+    d_use_bit_sync = (!d_secondary && d_symbols_per_bit > 1);
+    if (!d_use_bit_sync)
         {
             d_bit_sync.reset();
             return;
         }
 
     HistogramBitSynchronizer::Config cfg;
+    cfg.scheme = (d_systemName == "Glonass")
+                     ? HistogramBitSynchronizer::Scheme::kGlonassBiphase
+                     : HistogramBitSynchronizer::Scheme::kHistogram;
     cfg.bit_period_ms = d_symbols_per_bit * d_correlation_length_ms;
     cfg.epoch_ms = d_correlation_length_ms;
     d_bit_sync = HistogramBitSynchronizer(cfg);
@@ -1943,14 +1946,17 @@ int dll_pll_veml_tracking::general_work(int noutput_items __attribute__((unused)
                                     }
                                 else if (d_symbols_per_bit > 1)  // Signal does not have secondary code. Search a bit transition by sign change
                                     {
-                                        if (d_use_histogram_bit_sync)
+                                        if (d_use_bit_sync)
                                             {
                                                 next_state = d_bit_sync.update(d_P_accu, true);
                                                 if (next_state)
                                                     {
-                                                        LOG(INFO) << d_systemName << " " << d_signal_pretty_name << " histogram bit synchronization locked in channel " << d_channel
+                                                        const std::string lock_label = (d_systemName == "Glonass")
+                                                                                           ? "biphase symbol synchronization"
+                                                                                           : "histogram bit synchronization";
+                                                        LOG(INFO) << d_systemName << " " << d_signal_pretty_name << " " << lock_label << " locked in channel " << d_channel
                                                                   << " for satellite " << Gnss_Satellite(d_systemName, d_acquisition_gnss_synchro->PRN);
-                                                        std::cout << d_systemName << " " << d_signal_pretty_name << " histogram bit synchronization locked in channel " << d_channel
+                                                        std::cout << d_systemName << " " << d_signal_pretty_name << " " << lock_label << " locked in channel " << d_channel
                                                                   << " for satellite " << Gnss_Satellite(d_systemName, d_acquisition_gnss_synchro->PRN) << '\n';
                                                     }
                                             }

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.h
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.h
@@ -216,7 +216,7 @@ private:
     bool d_acc_carrier_phase_initialized;
     bool d_enable_extended_integration;
     bool d_Flag_PLL_180_deg_phase_locked;
-    bool d_use_histogram_bit_sync;
+    bool d_use_bit_sync;
 };
 
 

--- a/src/algorithms/tracking/libs/bit_synchronizer.cc
+++ b/src/algorithms/tracking/libs/bit_synchronizer.cc
@@ -19,6 +19,12 @@
 
 void HistogramBitSynchronizer::reset()
 {
+    if (cfg_.scheme == HistogramBitSynchronizer::Scheme::kGlonassBiphase)
+        {
+            glonass_sync_.reset();
+            return;
+        }
+
     std::fill(hist_.begin(), hist_.end(), 0);
     total_events_ = 0;
     epoch_count_ = 0;
@@ -39,6 +45,11 @@ void HistogramBitSynchronizer::reset()
 
 bool HistogramBitSynchronizer::update(const std::complex<float>& prompt, bool tracking_quality_ok)
 {
+    if (cfg_.scheme == HistogramBitSynchronizer::Scheme::kGlonassBiphase)
+        {
+            return glonass_sync_.update(prompt, tracking_quality_ok);
+        }
+
     const int N = bins();
     const int phase = (N > 0) ? static_cast<int>(epoch_count_ % N) : 0;
 
@@ -119,7 +130,7 @@ bool HistogramBitSynchronizer::update(const std::complex<float>& prompt, bool tr
 }
 
 
-bool HistogramBitSynchronizer::is_edge_epoch(std::int64_t k) const
+bool HistogramBitSynchronizer::is_histogram_edge_epoch(std::int64_t k) const
 {
     if (!locked_ || edge_phase_ < 0) return false;
     const int N = bins();
@@ -128,7 +139,7 @@ bool HistogramBitSynchronizer::is_edge_epoch(std::int64_t k) const
 }
 
 
-int HistogramBitSynchronizer::bins() const
+int HistogramBitSynchronizer::histogram_bins() const
 {
     const int N = (cfg_.epoch_ms > 0) ? (cfg_.bit_period_ms / cfg_.epoch_ms) : 0;
     return (N > 0) ? N : 0;
@@ -147,4 +158,199 @@ void HistogramBitSynchronizer::best_bin_and_count(int& best_bin, int& best_count
                     best_bin = i;
                 }
         }
+}
+
+
+GlonassBiphaseSymbolSynchronizer::Config HistogramBitSynchronizer::build_glonass_config(const Config& cfg)
+{
+    GlonassBiphaseSymbolSynchronizer::Config glonass_cfg;
+    glonass_cfg.symbol_period_ms = cfg.bit_period_ms;
+    glonass_cfg.epoch_ms = cfg.epoch_ms;
+    glonass_cfg.min_windows_for_lock = cfg.min_events_for_lock;
+    glonass_cfg.stable_best_required = cfg.stable_best_required;
+    glonass_cfg.min_prompt_mag = cfg.min_prompt_mag;
+    glonass_cfg.min_norm_score = cfg.dominance_ratio;
+    glonass_cfg.use_phase_dot_sign = cfg.use_phase_dot_detector;
+    return glonass_cfg;
+}
+
+
+GlonassBiphaseSymbolSynchronizer::GlonassBiphaseSymbolSynchronizer(const Config& cfg)
+    : cfg_(cfg),
+      N_(compute_bins(cfg)),
+      s_(),
+      template_(),
+      fill_(0),
+      epoch_count_(0),
+      windows_(0),
+      locked_(false),
+      symbol_phase_(-1),
+      has_last_prompt_(false),
+      last_prompt_(0.0f, 0.0f),
+      has_last_sign_(false),
+      last_sign_(+1),
+      has_last_best_(false),
+      last_best_(0),
+      stable_count_(0)
+{
+    s_.assign(N_, 0);
+    template_.assign(N_, 0);
+    for (int i = 0; i < N_; ++i)
+        {
+            template_[i] = (i < (N_ / 2)) ? +1 : -1;
+        }
+}
+
+
+void GlonassBiphaseSymbolSynchronizer::reset()
+{
+    std::fill(s_.begin(), s_.end(), 0);
+    fill_ = 0;
+    epoch_count_ = 0;
+    windows_ = 0;
+    locked_ = false;
+    symbol_phase_ = -1;
+
+    has_last_prompt_ = false;
+    last_prompt_ = std::complex<float>(0.0f, 0.0f);
+
+    has_last_sign_ = false;
+    last_sign_ = +1;
+
+    has_last_best_ = false;
+    last_best_ = 0;
+    stable_count_ = 0;
+}
+
+
+bool GlonassBiphaseSymbolSynchronizer::update(const std::complex<float>& prompt, bool tracking_quality_ok)
+{
+    if (N_ <= 0)
+        {
+            ++epoch_count_;
+            return false;
+        }
+
+    ++epoch_count_;
+
+    if (!tracking_quality_ok || (std::abs(prompt) < cfg_.min_prompt_mag))
+        {
+            last_prompt_ = prompt;
+            has_last_prompt_ = true;
+            return false;
+        }
+
+    const int sign = compute_sign(prompt);
+    push_sign(sign);
+
+    if (!buffer_full())
+        {
+            return false;
+        }
+
+    int best_p = 0;
+    int best_score = -1;
+
+    for (int p = 0; p < N_; ++p)
+        {
+            const int score = std::abs(correlation_score(p));
+            if (score > best_score)
+                {
+                    best_score = score;
+                    best_p = p;
+                }
+        }
+
+    ++windows_;
+
+    const double norm_score = static_cast<double>(best_score) / static_cast<double>(N_);
+
+    if (!has_last_best_ || (best_p != last_best_))
+        {
+            last_best_ = best_p;
+            has_last_best_ = true;
+            stable_count_ = 1;
+        }
+    else
+        {
+            ++stable_count_;
+        }
+
+    if (!locked_ &&
+        (windows_ >= cfg_.min_windows_for_lock) &&
+        (norm_score >= cfg_.min_norm_score) &&
+        (stable_count_ >= cfg_.stable_best_required))
+        {
+            locked_ = true;
+            symbol_phase_ = best_p;
+            return true;
+        }
+
+    return false;
+}
+
+
+bool GlonassBiphaseSymbolSynchronizer::is_symbol_epoch(std::int64_t k) const
+{
+    if (!locked_ || symbol_phase_ < 0 || N_ <= 0) return false;
+    return (static_cast<int>(k % N_) == symbol_phase_);
+}
+
+
+int GlonassBiphaseSymbolSynchronizer::compute_bins(const Config& cfg)
+{
+    if (cfg.epoch_ms <= 0) return 0;
+    const int N = cfg.symbol_period_ms / cfg.epoch_ms;
+    return (N > 0) ? N : 0;
+}
+
+
+int GlonassBiphaseSymbolSynchronizer::compute_sign(const std::complex<float>& prompt)
+{
+    if (cfg_.use_phase_dot_sign)
+        {
+            int s = +1;
+            if (has_last_prompt_)
+                {
+                    const double dot = static_cast<double>(std::real(prompt * std::conj(last_prompt_)));
+                    s = (dot >= 0.0) ? +1 : -1;
+                }
+            last_prompt_ = prompt;
+            has_last_prompt_ = true;
+            return s;
+        }
+
+    const int s = (std::real(prompt) >= 0.0f) ? +1 : -1;
+    has_last_sign_ = true;
+    last_sign_ = s;
+    return s;
+}
+
+
+void GlonassBiphaseSymbolSynchronizer::push_sign(int s)
+{
+    if (N_ <= 0)
+        {
+            return;
+        }
+
+    for (int i = 0; i < N_ - 1; ++i)
+        {
+            s_[i] = s_[i + 1];
+        }
+    s_[N_ - 1] = s;
+
+    if (fill_ < N_) ++fill_;
+}
+
+
+int GlonassBiphaseSymbolSynchronizer::correlation_score(int phase) const
+{
+    int sum = 0;
+    for (int i = 0; i < N_; ++i)
+        {
+            const int t = template_[(i + phase) % N_];
+            sum += s_[i] * t;
+        }
+    return sum;
 }

--- a/src/algorithms/tracking/libs/bit_synchronizer.h
+++ b/src/algorithms/tracking/libs/bit_synchronizer.h
@@ -29,11 +29,151 @@
 
 
 /**
+ * @brief GLONASS biphase (Manchester) symbol synchronizer.
+ *
+ * Estimates the symbol boundary for GLONASS signals by correlating sign
+ * transitions against a biphase template. The algorithm returns lock once
+ * the dominant phase bin is stable and sufficiently strong.
+ */
+class GlonassBiphaseSymbolSynchronizer
+{
+public:
+    /**
+     * @brief Configuration parameters for GlonassBiphaseSymbolSynchronizer.
+     */
+    struct Config
+    {
+        /**
+         * @brief Symbol period in milliseconds (GLONASS C/A: 10 ms).
+         */
+        int symbol_period_ms;
+
+        /**
+         * @brief Coherent integration interval in milliseconds (typically 1 ms).
+         */
+        int epoch_ms;
+
+        /**
+         * @brief Minimum number of windows required before lock evaluation.
+         */
+        int min_windows_for_lock;
+
+        /**
+         * @brief Required consecutive best-bin stability before lock.
+         */
+        int stable_best_required;
+
+        /**
+         * @brief Minimum magnitude of the prompt correlator output.
+         */
+        float min_prompt_mag;
+
+        /**
+         * @brief Minimum normalized correlation score required for lock.
+         */
+        double min_norm_score;
+
+        /**
+         * @brief Select the sign detector.
+         *
+         * If true, uses dot(Pk, Pk-1) sign; otherwise uses sign(Re(Pk)).
+         */
+        bool use_phase_dot_sign;
+
+        Config()
+            : symbol_period_ms(10),
+              epoch_ms(1),
+              min_windows_for_lock(30),
+              stable_best_required(8),
+              min_prompt_mag(0.0f),
+              min_norm_score(0.7),
+              use_phase_dot_sign(true)
+        {
+        }
+    };
+
+    /**
+     * @brief Construct a GLONASS biphase symbol synchronizer.
+     */
+    explicit GlonassBiphaseSymbolSynchronizer(const Config& cfg);
+
+    /**
+     * @brief Reset the synchronizer state.
+     */
+    void reset();
+
+    /**
+     * @brief Update the synchronizer once per epoch.
+     *
+     * @return True only when lock is first declared.
+     */
+    bool update(const std::complex<float>& prompt, bool tracking_quality_ok);
+
+    /**
+     * @brief Query whether the synchronizer has achieved lock.
+     */
+    bool locked() const { return locked_; }
+
+    /**
+     * @brief Estimated symbol phase bin in [0..N-1], or -1 if not locked.
+     */
+    int symbol_phase() const { return symbol_phase_; }
+
+    /**
+     * @brief Predict whether an epoch index corresponds to the symbol boundary.
+     */
+    bool is_symbol_epoch(std::int64_t k) const;
+
+    /**
+     * @brief Number of bins used by the synchronizer.
+     */
+    int bins() const { return N_; }
+
+private:
+    static int compute_bins(const Config& cfg);
+    int compute_sign(const std::complex<float>& prompt);
+    void push_sign(int s);
+    bool buffer_full() const { return (fill_ >= N_); }
+    int correlation_score(int phase) const;
+
+    Config cfg_;
+    int N_;
+    std::vector<int> s_;
+    std::vector<int> template_;
+    int fill_{0};
+
+    std::int64_t epoch_count_;
+    std::int64_t windows_;
+
+    bool locked_;
+    int symbol_phase_;
+
+    bool has_last_prompt_;
+    std::complex<float> last_prompt_;
+
+    bool has_last_sign_;
+    int last_sign_;
+
+    bool has_last_best_;
+    int last_best_;
+    int stable_count_;
+};
+
+/**
  * @brief Histogram-based navigation data bit synchronizer.
  */
 class HistogramBitSynchronizer
 {
 public:
+    /**
+     * @brief Supported synchronization schemes.
+     */
+    enum class Scheme
+    {
+        kHistogram,
+        kGlonassBiphase
+    };
+
     /**
      * @brief Configuration parameters for HistogramBitSynchronizer.
      *
@@ -42,6 +182,11 @@ public:
      */
     struct Config
     {
+        /**
+         * @brief Selected synchronization scheme.
+         */
+        Scheme scheme;
+
         /**
          * @brief Navigation data bit period in milliseconds.
          *
@@ -126,7 +271,8 @@ public:
         bool use_phase_dot_detector;
 
         Config()
-            : bit_period_ms(20),
+            : scheme(Scheme::kHistogram),
+              bit_period_ms(20),
               epoch_ms(1),
               min_events_for_lock(30),
               dominance_ratio(0.6),
@@ -158,9 +304,14 @@ public:
           locked_(false),
           has_last_prompt_(false),
           has_last_sign_(false),
-          has_last_best_bin_(false)
+          has_last_best_bin_(false),
+          glonass_sync_(GlonassBiphaseSymbolSynchronizer::Config())
     {
         hist_.assign(bins(), 0);
+        if (cfg_.scheme == Scheme::kGlonassBiphase)
+            {
+                glonass_sync_ = GlonassBiphaseSymbolSynchronizer(build_glonass_config(cfg_));
+            }
     }
 
     /**
@@ -199,7 +350,10 @@ public:
      *
      * @return True if lock has been declared, false otherwise.
      */
-    bool locked() const { return locked_; }
+    bool locked() const
+    {
+        return (cfg_.scheme == Scheme::kGlonassBiphase) ? glonass_sync_.locked() : locked_;
+    }
 
     /**
      * @brief Get the estimated bit edge phase bin.
@@ -210,7 +364,10 @@ public:
      *
      * @return Estimated edge phase bin index, or -1 if not locked.
      */
-    int edge_phase() const { return edge_phase_; }
+    int edge_phase() const
+    {
+        return (cfg_.scheme == Scheme::kGlonassBiphase) ? glonass_sync_.symbol_phase() : edge_phase_;
+    }
 
     /**
      * @brief Predict whether a given epoch index corresponds to a bit edge.
@@ -224,7 +381,10 @@ public:
      * @param k Epoch index (0-based, consistent with the caller's epoch counting).
      * @return True if @p k is the predicted edge epoch; false otherwise.
      */
-    bool is_edge_epoch(std::int64_t k) const;
+    bool is_edge_epoch(std::int64_t k) const
+    {
+        return (cfg_.scheme == Scheme::kGlonassBiphase) ? glonass_sync_.is_symbol_epoch(k) : is_histogram_edge_epoch(k);
+    }
 
     /**
      * @brief Return the number of histogram bins.
@@ -234,7 +394,10 @@ public:
      *
      * @return Number of histogram bins.
      */
-    int bins() const;
+    int bins() const
+    {
+        return (cfg_.scheme == Scheme::kGlonassBiphase) ? glonass_sync_.bins() : histogram_bins();
+    }
 
     /**
      * @brief Access the internal histogram (read-only).
@@ -264,6 +427,9 @@ public:
     std::int64_t get_epoch_count() const { return epoch_count_; }
 
 private:
+    static GlonassBiphaseSymbolSynchronizer::Config build_glonass_config(const Config& cfg);
+    bool is_histogram_edge_epoch(std::int64_t k) const;
+    int histogram_bins() const;
     void best_bin_and_count(int& best_bin, int& best_count) const;
 
     Config cfg_;
@@ -284,6 +450,8 @@ private:
     bool has_last_prompt_;    // Prompt history (for dot detector)
     bool has_last_sign_;      // Sign history (for simple detector)
     bool has_last_best_bin_;  // Stability tracking for best bin
+
+    GlonassBiphaseSymbolSynchronizer glonass_sync_;
 };
 
 /** \} */


### PR DESCRIPTION
### Motivation
- Reduce duplicated code paths for histogram and GLONASS biphase synchronization by centralizing selection into a single synchronizer instance.
- Allow the bit synchronizer behavior to be chosen via configuration instead of maintaining separate members for histogram and GLONASS sync.

### Description
- Add a `Scheme` option to `HistogramBitSynchronizer::Config` and wire a `GlonassBiphaseSymbolSynchronizer` instance inside `HistogramBitSynchronizer` to support both schemes via the same API, and add `build_glonass_config()` to map shared config fields to the GLONASS config.
- Delegate `reset()`, `update()`, `edge_phase()/is_edge_epoch()/bins()` and `locked()` to the internal GLONASS synchronizer when `Scheme::kGlonassBiphase` is selected, while preserving the original histogram logic for `Scheme::kHistogram`.
- Replace separate `d_glonass_bit_sync` and dual-flag logic with a single `d_bit_sync` and `d_use_bit_sync` flag in `dll_pll_veml_tracking`, and set `cfg.scheme` based on `d_systemName == "Glonass"` inside `configure_bit_synchronizer()`.
- Unify lock logging in the tracking loop to print an appropriate label (`"biphase symbol synchronization"` vs `"histogram bit synchronization"`) based on the configured scheme.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697125add934832c8cb6b69c41f8ca9f)