### PR TITLE
Defer extended integration to next histogram bit edge

### DIFF
--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
@@ -136,7 +136,9 @@ dll_pll_veml_tracking::dll_pll_veml_tracking(const Dll_Pll_Conf &conf_)
       d_dump_mat(d_trk_parameters.dump_mat && d_dump),
       d_acc_carrier_phase_initialized(false),
       d_Flag_PLL_180_deg_phase_locked(false),
-      d_use_histogram_bit_sync(false)
+      d_use_histogram_bit_sync(false),
+      d_wait_for_bit_edge(false),
+      d_bit_sync_lock_epoch(0)
 {
 #if GNURADIO_GREATER_THAN_38
     this->set_relative_rate(1, static_cast<uint64_t>(d_trk_parameters.vector_length));
@@ -1287,6 +1289,8 @@ void dll_pll_veml_tracking::clear_tracking_vars()
     d_carr_ph_history.clear();
     d_code_ph_history.clear();
     d_bit_sync.reset();
+    d_wait_for_bit_edge = false;
+    d_bit_sync_lock_epoch = 0;
 }
 
 
@@ -1945,13 +1949,25 @@ int dll_pll_veml_tracking::general_work(int noutput_items __attribute__((unused)
                                     {
                                         if (d_use_histogram_bit_sync)
                                             {
-                                                next_state = d_bit_sync.update(d_P_accu, true);
-                                                if (next_state)
+                                                const bool bit_sync_locked_now = d_bit_sync.update(d_P_accu, true);
+                                                if (bit_sync_locked_now)
                                                     {
                                                         LOG(INFO) << d_systemName << " " << d_signal_pretty_name << " histogram bit synchronization locked in channel " << d_channel
                                                                   << " for satellite " << Gnss_Satellite(d_systemName, d_acquisition_gnss_synchro->PRN);
                                                         std::cout << d_systemName << " " << d_signal_pretty_name << " histogram bit synchronization locked in channel " << d_channel
                                                                   << " for satellite " << Gnss_Satellite(d_systemName, d_acquisition_gnss_synchro->PRN) << '\n';
+                                                        d_wait_for_bit_edge = true;
+                                                        d_bit_sync_lock_epoch = d_bit_sync.get_epoch_count();
+                                                    }
+
+                                                if (d_wait_for_bit_edge && d_bit_sync.locked())
+                                                    {
+                                                        const int64_t epoch = d_bit_sync.get_epoch_count();
+                                                        if (d_bit_sync.is_edge_epoch(epoch) && epoch != d_bit_sync_lock_epoch)
+                                                            {
+                                                                next_state = true;
+                                                                d_wait_for_bit_edge = false;
+                                                            }
                                                     }
                                             }
 

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.h
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.h
@@ -217,6 +217,8 @@ private:
     bool d_enable_extended_integration;
     bool d_Flag_PLL_180_deg_phase_locked;
     bool d_use_histogram_bit_sync;
+    bool d_wait_for_bit_edge;
+    int64_t d_bit_sync_lock_epoch;
 };
 
 


### PR DESCRIPTION
### Motivation
- Avoid starting extended correlator integration immediately on histogram lock to prevent spanning a telemetry bit transition and corrupting extended integration results.
- Track the histogram lock epoch so the code can wait for the next predicted bit edge before enabling extended integration.
- Ensure the waiting state is cleared when tracking variables are reset.

### Description
- Added two new member variables to `dll_pll_veml_tracking`: `d_wait_for_bit_edge` and `d_bit_sync_lock_epoch` to track waiting-for-edge state and the lock epoch, respectively.
- Initialized the new members in the constructor and reset them in `clear_tracking_vars()`.
- Modified the histogram bit-sync handling in `general_work()` to record when histogram locking first occurs and defer transition to extended integration until a subsequent bit-edge epoch is observed (only then `next_state` becomes true).
- Replaced the previous immediate `d_bit_sync.update(...)`-to-transition behavior with a two-step: mark locked and wait for the next edge before enabling extended integration.

### Testing
- No automated tests were executed for this change.
- Changes were compiled/committed locally as part of development (no CI results included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a1a7bfe40832caa9a9ff68439b738)