### PR TITLE
Add TOW continuity checks to GPS L1 CA telemetry decoder

### DIFF
--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_gs.cc
@@ -29,6 +29,7 @@
 #include "tow_to_trk.h"
 #include <pmt/pmt.h>        // for make_any
 #include <pmt/pmt_sugar.h>  // for mp
+#include <algorithm>        // for min
 #include <bitset>           // for bitset
 #include <cmath>            // for round
 #include <cstddef>          // for size_t
@@ -66,6 +67,13 @@ namespace wht = boost;
 namespace wht = std;
 #endif
 
+namespace
+{
+constexpr uint32_t GPS_WEEK_SECONDS = 604800U;
+constexpr uint32_t GPS_L1_CA_SYMBOL_RATE_HZ = 50U;  // 1 symbol every 20 ms
+constexpr uint32_t TOW_CONTINUITY_TOLERANCE_S = 2U;
+}  // namespace
+
 gps_l1_ca_telemetry_decoder_gs_sptr
 gps_l1_ca_make_telemetry_decoder_gs(const Gnss_Satellite &satellite, const Tlm_Conf &conf, L1LnavSystem system)
 {
@@ -94,6 +102,8 @@ gps_l1_ca_telemetry_decoder_gs::gps_l1_ca_telemetry_decoder_gs(
                            d_stat(0),
                            d_TOW_at_Preamble_ms(0),
                            d_TOW_at_current_symbol_ms(0),
+                           d_last_decoded_tow_s(0),
+                           d_last_decoded_tow_sample_counter(0),
                            d_flag_frame_sync(false),
                            d_flag_preamble(false),
                            d_sent_tlm_failed_msg(false),
@@ -104,7 +114,8 @@ gps_l1_ca_telemetry_decoder_gs::gps_l1_ca_telemetry_decoder_gs(
                            d_remove_dat(conf.remove_dat),
                            d_enable_navdata_monitor(conf.enable_navdata_monitor),
                            d_dump_crc_stats(conf.dump_crc_stats),
-                           d_tow_to_trk(conf.tow_to_trk)
+                           d_tow_to_trk(conf.tow_to_trk),
+                           d_have_last_decoded_tow(false)
 {
     configure_basic_outputs();
 
@@ -358,6 +369,15 @@ bool gps_l1_ca_telemetry_decoder_gs::decode_subframe(double cn0, bool flag_inver
             const int32_t subframe_ID = d_nav->subframe_decoder(subframe.data());  // decode the subframe
             if (subframe_ID > 0 && subframe_ID < 6)
                 {
+                    const uint32_t decoded_tow_s = static_cast<uint32_t>(d_nav->get_TOW());
+                    if (!is_tow_consistent(decoded_tow_s))
+                        {
+                            DLOG(INFO) << "Rejected " << ((d_system == L1LnavSystem::GPS) ? "GPS" : "QZSS")
+                                       << " L1 NAV subframe in channel " << d_channel
+                                       << " due to inconsistent TOW. Decoded TOW=" << decoded_tow_s
+                                       << " s at d_sample_counter=" << d_sample_counter;
+                            return false;
+                        }
                     switch (subframe_ID)
                         {
                         case 1:
@@ -431,12 +451,44 @@ bool gps_l1_ca_telemetry_decoder_gs::decode_subframe(double cn0, bool flag_inver
 }
 
 
+bool gps_l1_ca_telemetry_decoder_gs::is_tow_consistent(uint32_t decoded_tow_s)
+{
+    if (!d_have_last_decoded_tow)
+        {
+            d_last_decoded_tow_s = decoded_tow_s;
+            d_last_decoded_tow_sample_counter = d_sample_counter;
+            d_have_last_decoded_tow = true;
+            return true;
+        }
+
+    const uint64_t elapsed_samples = d_sample_counter - d_last_decoded_tow_sample_counter;
+    const uint32_t elapsed_time_s = static_cast<uint32_t>(std::llround(static_cast<double>(elapsed_samples) / static_cast<double>(GPS_L1_CA_SYMBOL_RATE_HZ)));
+    const uint32_t expected_tow_s = (d_last_decoded_tow_s + elapsed_time_s) % GPS_WEEK_SECONDS;
+    const uint32_t forward_error_s = (decoded_tow_s + GPS_WEEK_SECONDS - expected_tow_s) % GPS_WEEK_SECONDS;
+    const uint32_t reverse_error_s = (expected_tow_s + GPS_WEEK_SECONDS - decoded_tow_s) % GPS_WEEK_SECONDS;
+    const uint32_t tow_error_s = std::min(forward_error_s, reverse_error_s);
+
+    if (tow_error_s > TOW_CONTINUITY_TOLERANCE_S)
+        {
+            d_have_last_decoded_tow = false;
+            return false;
+        }
+
+    d_last_decoded_tow_s = decoded_tow_s;
+    d_last_decoded_tow_sample_counter = d_sample_counter;
+    return true;
+}
+
+
 void gps_l1_ca_telemetry_decoder_gs::reset()
 {
     gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
     d_last_valid_preamble = d_sample_counter;
     d_sent_tlm_failed_msg = false;
     d_flag_TOW_set = false;
+    d_have_last_decoded_tow = false;
+    d_last_decoded_tow_s = 0;
+    d_last_decoded_tow_sample_counter = 0;
     d_symbol_history.clear();
     d_stat = 0;
     DLOG(INFO) << "Telemetry decoder reset for satellite " << d_satellite;

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_gs.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_gs.h
@@ -82,6 +82,7 @@ private:
     bool is_PLL_180_deg_phase_locked();
     bool gps_word_parityCheck(uint32_t gpsword);
     bool decode_subframe(double cn0, bool flag_invert);
+    bool is_tow_consistent(uint32_t decoded_tow_s);
 
     L1LnavSystem d_system;
     std::unique_ptr<Gps_Navigation_Message> d_nav;
@@ -112,6 +113,8 @@ private:
     uint32_t d_stat;
     uint32_t d_TOW_at_Preamble_ms;
     uint32_t d_TOW_at_current_symbol_ms;
+    uint32_t d_last_decoded_tow_s;
+    uint64_t d_last_decoded_tow_sample_counter;
 
     bool d_flag_frame_sync;
     bool d_flag_preamble;
@@ -124,6 +127,7 @@ private:
     bool d_enable_navdata_monitor;
     bool d_dump_crc_stats;
     bool d_tow_to_trk;
+    bool d_have_last_decoded_tow;
 };
 
 


### PR DESCRIPTION
### Motivation
- Prevent acceptance of NAV subframes whose decoded Time-Of-Week (TOW) is inconsistent with previously decoded TOW values to avoid propagating spurious/stale navigation data.
- Track decoded-TOW and sample timing across decoded subframes to enforce continuity while handling week rollovers.
- Provide a simple tolerance-based guard to reject anomalous TOW changes arising from decoding errors or short-lived false locks.

### Description
- Added constants `GPS_WEEK_SECONDS`, `GPS_L1_CA_SYMBOL_RATE_HZ`, and `TOW_CONTINUITY_TOLERANCE_S` and included `<algorithm>` for `std::min` usage. 
- Introduced members `d_last_decoded_tow_s`, `d_last_decoded_tow_sample_counter`, and `d_have_last_decoded_tow` and initialized them in the constructor and `reset()` to track last decoded TOW and its sample counter. 
- Implemented `is_tow_consistent(uint32_t decoded_tow_s)` which computes expected elapsed seconds from sample counters, handles GPS week wrap-around, and rejects decoded TOWs that differ by more than `TOW_CONTINUITY_TOLERANCE_S`. 
- Integrated the check into `decode_subframe()` to log and reject NAV subframes with inconsistent TOW, and updated the header to declare the new function and members. 

### Testing
- Built the project to verify compilation with the new headers and symbols using the existing build system, and the build completed successfully. 
- Ran the project's automated unit test suite including telemetry/decoder tests, and all tests passed. 
- Exercised the decoder in typical telemetry processing scenarios to validate that inconsistent TOWs are rejected without affecting valid continuity, and no automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d936ba3794832c95a3bba421593e88)